### PR TITLE
Fix DST bounds across torch versions

### DIFF
--- a/interpol/bounds.py
+++ b/interpol/bounds.py
@@ -1,6 +1,7 @@
 import torch
 from enum import Enum
 from typing import Optional
+from .jit_utils import floor_div
 Tensor = torch.Tensor
 
 
@@ -69,13 +70,13 @@ class Bound:
             i = i.remainder(n2)
             x = torch.where(i == 0, zero, one)
             x = torch.where(i.remainder(n + 1) == n, zero, x)
-            i = i // (n+1)
+            i = floor_div(i, n+1)
             x = torch.where(torch.remainder(i, 2) > 0, -x, x)
             return x
         elif self.type == 5:  # dst2
             i = torch.where(i < 0, n - 1 - i, i)
             x = torch.ones([1], dtype=torch.int8, device=i.device)
-            i = i // n
+            i = floor_div(i, n)
             x = torch.where(torch.remainder(i, 2) > 0, -x, x)
             return x
         elif self.type == 0:  # zero

--- a/interpol/bounds.py
+++ b/interpol/bounds.py
@@ -69,12 +69,14 @@ class Bound:
             i = i.remainder(n2)
             x = torch.where(i == 0, zero, one)
             x = torch.where(i.remainder(n + 1) == n, zero, x)
-            x = torch.where((i // (n+1)).remainder(2) > 0, -x, x)
+            i = i // (n+1)
+            x = torch.where(torch.remainder(i, 2) > 0, -x, x)
             return x
         elif self.type == 5:  # dst2
             i = torch.where(i < 0, n - 1 - i, i)
             x = torch.ones([1], dtype=torch.int8, device=i.device)
-            x = torch.where((i // n).remainder(2) > 0, -x, x)
+            i = i // n
+            x = torch.where(torch.remainder(i, 2) > 0, -x, x)
             return x
         elif self.type == 0:  # zero
             one = torch.ones([1], dtype=torch.int8, device=i.device)

--- a/interpol/bounds.py
+++ b/interpol/bounds.py
@@ -69,12 +69,12 @@ class Bound:
             i = i.remainder(n2)
             x = torch.where(i == 0, zero, one)
             x = torch.where(i.remainder(n + 1) == n, zero, x)
-            x = torch.where(i.floor_divide(n+1).remainder(2) > 0, -x, x)
+            x = torch.where(torch.floor_divide(i, n+1).remainder(2) > 0, -x, x)
             return x
         elif self.type == 5:  # dst2
             i = torch.where(i < 0, n - 1 - i, i)
             x = torch.ones([1], dtype=torch.int8, device=i.device)
-            x = torch.where(i.floor_divide(n).remainder(2) > 0, -x, x)
+            x = torch.where(torch.floor_divide(i, n).remainder(2) > 0, -x, x)
             return x
         elif self.type == 0:  # zero
             one = torch.ones([1], dtype=torch.int8, device=i.device)

--- a/interpol/bounds.py
+++ b/interpol/bounds.py
@@ -69,12 +69,12 @@ class Bound:
             i = i.remainder(n2)
             x = torch.where(i == 0, zero, one)
             x = torch.where(i.remainder(n + 1) == n, zero, x)
-            x = torch.where(torch.floor_divide(i, n+1).remainder(2) > 0, -x, x)
+            x = torch.where((i // (n+1)).remainder(2) > 0, -x, x)
             return x
         elif self.type == 5:  # dst2
             i = torch.where(i < 0, n - 1 - i, i)
             x = torch.ones([1], dtype=torch.int8, device=i.device)
-            x = torch.where(torch.floor_divide(i, n).remainder(2) > 0, -x, x)
+            x = torch.where((i // n).remainder(2) > 0, -x, x)
             return x
         elif self.type == 0:  # zero
             one = torch.ones([1], dtype=torch.int8, device=i.device)

--- a/interpol/jit_utils.py
+++ b/interpol/jit_utils.py
@@ -427,3 +427,17 @@ else:
 
 
 meshgrid = meshgrid_ij
+
+
+# In torch < 1.6, div applied to integer tensor performed a floor_divide
+# In torch > 1.6, it performs a true divide.
+# Floor division must be done using `floor_divide`, but it was buggy
+# until torch 1.13 (it was doing a trunc divide instead of a floor divide).
+# There was at some point a deprecation warning for floor_divide, but it
+# seems to have been lifted afterwards. In torch >= 1.13, floor_divide
+# performs a correct floor division.
+# Since we only apply floor_divide ot positive values, we are fine.
+if torch_version('<', (1, 6)):
+    floor_div = torch.div
+else:
+    floor_div = torch.floor_divide


### PR DESCRIPTION
- In torch < 1.6, `div` applied to integer tensor performed a floor division
- In torch > 1.6, it performs a true divide.
- After 1.6, floor division must be done using `floor_divide`, but it was buggy
until torch 1.13 (it was doing a trunc divide instead of a floor divide).
- There was at some point a deprecation warning for `floor_divide`, 
but it seems to have been lifted afterwards. In torch >= 1.13,` floor_divide`
performs a correct floor division.
- Since we only apply `floor_divide` to positive values, we are fine.